### PR TITLE
Upgrade tokio-rustls to v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 0.2.9",
  "js-sys",
  "pin-project",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.9.3",
  "slab",
  "tokio",
@@ -1238,7 +1238,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.9",
  "httpdate",
  "mime",
  "sha1",
@@ -1250,7 +1250,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.9",
 ]
 
 [[package]]
@@ -1313,13 +1313,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
@@ -1362,7 +1373,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "httparse",
  "httpdate",
@@ -1382,10 +1393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.9",
  "hyper",
  "rustls 0.21.5",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1700,7 +1711,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "memchr",
@@ -2229,7 +2240,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -2241,7 +2252,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.5",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2432,8 +2443,22 @@ checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring 0.16.20",
- "rustls-webpki",
+ "rustls-webpki 0.101.4",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2443,7 +2468,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -2458,6 +2496,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64 0.21.2",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2519,17 @@ checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring 0.16.20",
  "untrusted 0.7.1",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+dependencies = [
+ "ring 0.17.7",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2849,7 +2914,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls 0.21.5",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
  "serde",
  "serde_json",
  "sha2",
@@ -3115,8 +3180,8 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rpassword",
- "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.0.0",
  "sailfish",
  "serde",
  "serde_default",
@@ -3131,9 +3196,9 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
- "tokio-tungstenite 0.20.0",
+ "tokio-tungstenite 0.21.0",
  "toml 0.8.8",
  "toml_edit 0.21.0",
  "totp-rs",
@@ -3332,6 +3397,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,17 +3433,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.5",
- "rustls-native-certs",
+ "rustls 0.22.2",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
- "tungstenite 0.20.0",
+ "tokio-rustls 0.25.0",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -3562,7 +3639,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "bytes",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand",
@@ -3574,18 +3651,19 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.0.0",
  "httparse",
  "log",
  "rand",
- "rustls 0.21.5",
+ "rustls 0.22.2",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "url",
@@ -3768,7 +3846,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http",
+ "http 0.2.9",
  "hyper",
  "log",
  "mime",
@@ -3776,7 +3854,7 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -3910,7 +3988,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
- "rustls-webpki",
+ "rustls-webpki 0.101.4",
 ]
 
 [[package]]

--- a/taxy/Cargo.toml
+++ b/taxy/Cargo.toml
@@ -50,8 +50,8 @@ pkcs8 = { version = "0.10.2", features = ["pem"] }
 rand = "0.8.5"
 rcgen = { version = "0.12.0", features = ["pem", "x509-parser"] }
 rpassword = "7.2.0"
-rustls-native-certs = "0.6.3"
-rustls-pemfile = "1.0.3"
+rustls-native-certs = "0.7.0"
+rustls-pemfile = "2.0.0"
 sailfish = "0.8.0"
 serde = { version = "1.0.171", features = ["rc"] }
 serde_default = "0.1.0"
@@ -76,8 +76,9 @@ tokio = { version = "1.29.1", features = [
     "signal",
     "io-util",
 ] }
-tokio-rustls = { version = "0.24.1", default-features = false, features = [
+tokio-rustls = { version = "0.25.0", default-features = false, features = [
     "tls12",
+    "ring",
 ] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 toml = "0.8.8"
@@ -106,7 +107,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "json",
     "stream",
 ] }
-tokio-tungstenite = { version = "0.20.0", features = [
+tokio-tungstenite = { version = "0.21.0", features = [
     "rustls-tls-native-roots",
 ] }
 warp = { version = "0.3.5", features = ["tls"] }

--- a/taxy/src/proxy/http/hyper_tls/client.rs
+++ b/taxy/src/proxy/http/hyper_tls/client.rs
@@ -6,7 +6,8 @@ use std::task::{Context, Poll};
 
 use hyper::{client::connect::HttpConnector, service::Service, Uri};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_rustls::rustls::{ClientConfig, ServerName};
+use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::rustls::ClientConfig;
 use tokio_rustls::TlsConnector;
 
 use super::stream::MaybeHttpsStream;
@@ -108,7 +109,7 @@ where
             let tcp = connecting.await.map_err(Into::into)?;
             let maybe = if is_https {
                 let tls = tls
-                    .connect(ServerName::try_from(host.as_str()).unwrap(), tcp)
+                    .connect(ServerName::try_from(host.as_str()).unwrap().to_owned(), tcp)
                     .await?;
                 MaybeHttpsStream::Https(tls)
             } else {

--- a/taxy/src/proxy/http/mod.rs
+++ b/taxy/src/proxy/http/mod.rs
@@ -30,7 +30,7 @@ use tokio::{
     net::TcpStream,
 };
 use tokio_rustls::{
-    rustls::{client::ServerName, ClientConfig, RootCertStore},
+    rustls::{pki_types::ServerName, ClientConfig, RootCertStore},
     TlsAcceptor,
 };
 use tracing::{debug, error, info, span, Instrument, Level, Span};
@@ -83,7 +83,6 @@ impl HttpPortContext {
             tls_termination,
             tls_client_config: Arc::new(
                 ClientConfig::builder()
-                    .with_safe_defaults()
                     .with_root_certificates(RootCertStore::empty())
                     .with_no_client_auth(),
             ),
@@ -106,7 +105,6 @@ impl HttpPortContext {
         }));
 
         let config = ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(certs.root_certs().clone())
             .with_no_client_auth();
         self.tls_client_config = Arc::new(config);
@@ -339,7 +337,7 @@ impl<S> IoStream for S where S: AsyncRead + AsyncWrite + Unpin + Send {}
 
 #[derive(Debug, Clone)]
 pub struct Connection {
-    pub name: ServerName,
+    pub name: ServerName<'static>,
     pub port: u16,
     pub tls: bool,
 }

--- a/taxy/src/proxy/http/pool.rs
+++ b/taxy/src/proxy/http/pool.rs
@@ -121,9 +121,8 @@ async fn start_upgrading_connection(
     if conn.scheme == Scheme::HTTPS {
         debug!(%resolved, "client: tls handshake");
         let tls = TlsConnector::from(tls_client_config);
-        let tls_stream = tls
-            .connect(conn.authority.host().try_into().unwrap(), stream)
-            .await?;
+        let host = conn.authority.host().to_string();
+        let tls_stream = tls.connect(host.try_into().unwrap(), stream).await?;
         stream = Box::new(tls_stream);
     }
 

--- a/taxy/src/proxy/http/route.rs
+++ b/taxy/src/proxy/http/route.rs
@@ -5,7 +5,7 @@ use taxy_api::{
     id::ShortId,
     proxy::{ProxyEntry, ProxyKind, Route, Server},
 };
-use tokio_rustls::rustls::ServerName;
+use tokio_rustls::rustls::pki_types::ServerName;
 use url::Url;
 use warp::host::Authority;
 
@@ -76,7 +76,7 @@ impl TryFrom<Route> for ParsedRoute {
 pub struct ParsedServer {
     pub url: Url,
     pub authority: Authority,
-    pub server_name: ServerName,
+    pub server_name: ServerName<'static>,
 }
 
 impl TryFrom<Server> for ParsedServer {
@@ -98,9 +98,11 @@ impl TryFrom<Server> for ParsedServer {
         .map_err(|_| Error::InvalidServerUrl {
             url: server.url.clone(),
         })?;
-        let server_name = ServerName::try_from(hostname).map_err(|_| Error::InvalidServerUrl {
-            url: server.url.clone(),
-        })?;
+        let server_name = ServerName::try_from(hostname)
+            .map_err(|_| Error::InvalidServerUrl {
+                url: server.url.clone(),
+            })?
+            .to_owned();
         Ok(Self {
             url: server.url,
             authority,

--- a/taxy/src/proxy/tls.rs
+++ b/taxy/src/proxy/tls.rs
@@ -58,7 +58,6 @@ impl TlsTermination {
         ));
 
         let mut server_config = ServerConfig::builder()
-            .with_safe_defaults()
             .with_no_client_auth()
             .with_cert_resolver(resolver);
         server_config
@@ -72,6 +71,7 @@ impl TlsTermination {
     }
 }
 
+#[derive(Debug)]
 pub struct CertResolver {
     certs: Vec<Arc<Cert>>,
     default_names: Vec<SubjectName>,

--- a/taxy/src/server/cert_list.rs
+++ b/taxy/src/server/cert_list.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use log::warn;
 use std::sync::Arc;
 use taxy_api::{cert::CertKind, error::Error, id::ShortId};
-use tokio_rustls::rustls::{Certificate, RootCertStore};
+use tokio_rustls::rustls::RootCertStore;
 
 #[derive(Debug)]
 pub struct CertList {
@@ -25,8 +25,8 @@ impl CertList {
         {
             match certs {
                 Ok(certs) => {
-                    for certs in certs {
-                        if let Err(err) = system_root_certs.add(&Certificate(certs.0)) {
+                    for cert in certs {
+                        if let Err(err) = system_root_certs.add(cert) {
                             warn!("failed to add native certs: {err}");
                         }
                     }
@@ -96,7 +96,7 @@ impl CertList {
             if cert.kind == CertKind::Root {
                 if let Ok(certs) = cert.certificates() {
                     for cert in certs {
-                        if let Err(err) = root_certs.add(&cert) {
+                        if let Err(err) = root_certs.add(cert) {
                             warn!("failed to add root cert: {}", err);
                         }
                     }

--- a/taxy/tests/wss_test.rs
+++ b/taxy/tests/wss_test.rs
@@ -81,11 +81,10 @@ async fn wss_proxy() -> anyhow::Result<()> {
 
     let mut root_certs = RootCertStore::empty();
     for cert in root.certified_key().unwrap().cert {
-        root_certs.add(&cert).unwrap();
+        root_certs.add(cert).unwrap();
     }
 
     let client = ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_certs)
         .with_no_client_auth();
 


### PR DESCRIPTION
This pull request upgrades the tokio-rustls dependency to version 0.25.0. It includes several changes and improvements to the codebase.