### PR TITLE
Fix secure flag in cookie attribute

### DIFF
--- a/taxy/src/admin/auth.rs
+++ b/taxy/src/admin/auth.rs
@@ -78,7 +78,7 @@ pub async fn login(
                 warp::reply::json(&res),
                 "Set-Cookie",
                 &format!(
-                    "token={}; HttpOnly; SameProxy=Strict; Secure",
+                    "token={}; HttpOnly; SameSite=Strict; Secure",
                     state
                         .data
                         .lock()


### PR DESCRIPTION
This pull request fixes the secure flag in the cookie attribute in the webui module. The previous code used "SameProxy" instead of "SameSite" for the cookie attribute. This change ensures that the secure flag is set correctly.