### PR TITLE
Add --insecure-webui option to taxy start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ $ taxy start
 
 Once the server is running, you can access the admin panel at [http://localhost:46492/](http://localhost:46492/).
 
+WebUI uses [`Secure`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure) cookie attribute to store the session token. This means that the WebUI will only work over HTTPS, unless it is served on localhost (although certain browsers, like Safari, may deny this even on localhost). If you want to use the WebUI over HTTP, you can use the `--insecure-webui` command-line option.
+
+```bash
+$ taxy start --insecure-webui
+```
+
 ## Development
 
 To contribute or develop Taxy, follow these steps:

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -76,6 +76,8 @@ If needed, these files can be edited manually. Note, however, that Taxy does not
 
 Taxy includes a built-in WebUI. By default, it is served on localhost:46492. However, you can customize the port using the `TAXY_WEBUI` environment variable or the `--webui` command-line option. If you wish to disable the WebUI, set the `TAXY_NO_WEBUI=1` environment variable or use the `--no-webui` command-line option.
 
+WebUI uses [`Secure`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure) cookie attribute to store the session token. This means that the WebUI will only work over HTTPS, unless it is served on localhost (although certain browsers, like Safari, may deny this even on localhost). If you want to use the WebUI over HTTP, you can set the `TAXY_INSECURE_WEBUI=1` environment variable or use the `--insecure-webui` command-line option. Note that this is not recommended.
+
 # Logging
 
 Taxy logs to the standard output as its default setting. You can change this behavior by setting the `TAXY_LOG`, `TAXY_ACCESS_LOG` environment variable or using the `--log`, `--access-log` command-line option.

--- a/taxy/src/admin/auth.rs
+++ b/taxy/src/admin/auth.rs
@@ -74,11 +74,13 @@ pub async fn login(
                 LoginResponse::Success => SessionKind::Admin,
                 _ => SessionKind::Login,
             };
+            let insecure = state.data.lock().await.insecure;
+            let secure_cookie = if insecure { "" } else { "Secure" };
             Ok(warp::reply::with_header(
                 warp::reply::json(&res),
                 "Set-Cookie",
                 &format!(
-                    "token={}; HttpOnly; SameSite=Strict; Secure",
+                    "token={}; HttpOnly; SameSite=Strict; {secure_cookie}",
                     state
                         .data
                         .lock()

--- a/taxy/src/args.rs
+++ b/taxy/src/args.rs
@@ -64,6 +64,9 @@ pub struct StartArgs {
     #[clap(long, short, env = "TAXY_NO_WEBUI", conflicts_with = "webui")]
     pub no_webui: bool,
 
+    #[clap(long, env = "TAXY_INSECURE_WEBUI", conflicts_with = "no_webui")]
+    pub insecure_webui: bool,
+
     #[clap(long, short, value_name = "DIR", env = "TAXY_CONFIG_DIR")]
     pub config_dir: Option<PathBuf>,
 

--- a/taxy/src/main.rs
+++ b/taxy/src/main.rs
@@ -68,7 +68,7 @@ async fn start(args: StartArgs) -> anyhow::Result<()> {
 
     let webui_enabled = !args.no_webui;
     tokio::select! {
-        r = taxy::admin::start_admin(app_info, args.webui, channels.command, channels.callback, channels.event), if webui_enabled => {
+        r = taxy::admin::start_admin(app_info, args.webui, args.insecure_webui, channels.command, channels.callback, channels.event), if webui_enabled => {
             if let Err(err) = r {
                 error!("admin error: {}", err);
             }


### PR DESCRIPTION
This pull request adds the --insecure-webui option to the taxy start command. The option allows the WebUI to be served over HTTP instead of HTTPS, but it is not recommended for security reasons.