### PR TITLE
Fix vhost resolution issue in HTTP/2

### DIFF
--- a/taxy/src/proxy/http/filter.rs
+++ b/taxy/src/proxy/http/filter.rs
@@ -23,7 +23,11 @@ impl RequestFilter {
     }
 
     pub fn test<T>(&self, req: &Request<T>) -> Option<FilterResult> {
-        let host = req.headers().get("host").and_then(|v| v.to_str().ok());
+        let host = req
+            .uri()
+            .authority()
+            .map(|auth| auth.as_str())
+            .or_else(|| req.headers().get("host").and_then(|v| v.to_str().ok()));
         let host_matched = match host {
             Some(host) => self.vhosts.iter().any(|vhost| vhost.test(host)),
             None => false,

--- a/taxy/tests/https_test.rs
+++ b/taxy/tests/https_test.rs
@@ -48,7 +48,7 @@ async fn https_proxy() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![],
+                    vhosts: vec![proxy_port.subject_name()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
@@ -144,7 +144,7 @@ async fn https_proxy_invalid_cert() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![],
+                    vhosts: vec![proxy_port.subject_name()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
@@ -221,7 +221,7 @@ async fn https_proxy_automatic_upgrade() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![],
+                    vhosts: vec![proxy_port.subject_name()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
@@ -313,7 +313,7 @@ async fn https_proxy_domain_fronting() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![],
+                    vhosts: vec![proxy_port.subject_name()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {

--- a/taxy/tests/wss_test.rs
+++ b/taxy/tests/wss_test.rs
@@ -61,7 +61,7 @@ async fn wss_proxy() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![],
+                    vhosts: vec![proxy_port.subject_name()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {


### PR DESCRIPTION
This pull request fixes a vhost resolution issue in the HTTP/2 implementation. The issue was causing incorrect host resolution when handling requests. The fix ensures that the correct host is used for request handling.