### PR TITLE
Fix vhost matching in http proxy

### DIFF
--- a/taxy/tests/common.rs
+++ b/taxy/tests/common.rs
@@ -219,10 +219,6 @@ impl TestPort {
         self.addr
     }
 
-    pub fn subject_name(&self) -> SubjectName {
-        format!("localhost:{}", self.addr.port()).parse().unwrap()
-    }
-
     pub fn multiaddr_http(&self) -> Multiaddr {
         let protocol = if self.addr.is_ipv4() { "ip4" } else { "ip6" };
         let addr = self.addr.ip();

--- a/taxy/tests/http_test.rs
+++ b/taxy/tests/http_test.rs
@@ -77,7 +77,7 @@ async fn http_proxy() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
@@ -171,7 +171,7 @@ async fn http_proxy_dns_error() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {

--- a/taxy/tests/https_test.rs
+++ b/taxy/tests/https_test.rs
@@ -48,7 +48,7 @@ async fn https_proxy() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
@@ -144,7 +144,7 @@ async fn https_proxy_invalid_cert() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
@@ -221,7 +221,7 @@ async fn https_proxy_automatic_upgrade() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
@@ -313,7 +313,7 @@ async fn https_proxy_domain_fronting() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {

--- a/taxy/tests/ws_test.rs
+++ b/taxy/tests/ws_test.rs
@@ -46,7 +46,7 @@ async fn ws_proxy() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {

--- a/taxy/tests/wss_test.rs
+++ b/taxy/tests/wss_test.rs
@@ -61,7 +61,7 @@ async fn wss_proxy() -> anyhow::Result<()> {
             proxy: Proxy {
                 ports: vec!["test".parse().unwrap()],
                 kind: ProxyKind::Http(HttpProxy {
-                    vhosts: vec![proxy_port.subject_name()],
+                    vhosts: vec!["localhost".parse().unwrap()],
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {


### PR DESCRIPTION
This pull request fixes the vhost matching in the http proxy by correctly handling the authority header and ignoring the port number in vhost matching.