### PR TITLE
Support wss scheme in target server URL

### DIFF
--- a/taxy/src/proxy/http/mod.rs
+++ b/taxy/src/proxy/http/mod.rs
@@ -270,13 +270,10 @@ async fn start(
                 res.uri.path_and_query().cloned()
             };
 
-            if !route.servers.is_empty() {
-                let server = &route.servers[0];
-
-                parts.scheme = Some(if server.url.scheme() == "http" {
-                    Scheme::HTTP
-                } else {
-                    Scheme::HTTPS
+            if let Some(server) = route.servers.get(0) {
+                parts.scheme = Some(match server.url.scheme() {
+                    "https" | "wss" => Scheme::HTTPS,
+                    _ => Scheme::HTTP,
                 });
 
                 let authority = server.authority.clone();


### PR DESCRIPTION
This pull request adds support for the wss scheme in the target server URL. Previously, only the http and https schemes were supported. With this change, the application will be able to handle WebSocket connections using the wss scheme.