### PR TITLE
Use fmt::Display instead of fmt::Debug in logging if possible

### DIFF
--- a/taxy/src/certs/mod.rs
+++ b/taxy/src/certs/mod.rs
@@ -222,7 +222,7 @@ impl Cert {
         let cert = match rcgen::Certificate::from_params(params) {
             Ok(cert) => cert,
             Err(err) => {
-                error!(?err);
+                error!(%err);
                 return Err(Error::FailedToGerateSelfSignedCertificate);
             }
         };
@@ -249,7 +249,7 @@ impl Cert {
         let ca_cert = match rcgen::Certificate::from_params(ca_params) {
             Ok(cert) => cert,
             Err(err) => {
-                error!(?err);
+                error!(%err);
                 return Err(Error::FailedToGerateSelfSignedCertificate);
             }
         };
@@ -278,7 +278,7 @@ impl Cert {
         let cert = match rcgen::Certificate::from_params(params) {
             Ok(cert) => cert,
             Err(err) => {
-                error!(?err);
+                error!(%err);
                 return Err(Error::FailedToGerateSelfSignedCertificate);
             }
         };
@@ -301,7 +301,7 @@ impl Cert {
         match self.certified_impl() {
             Ok(certified) => Ok(certified),
             Err(err) => {
-                error!(?err);
+                error!(%err);
                 Err(Error::FailedToReadPrivateKey)
             }
         }

--- a/taxy/src/config/file.rs
+++ b/taxy/src/config/file.rs
@@ -76,7 +76,7 @@ impl FileStorage {
         let mut doc = match self.load_document(path).await {
             Ok(doc) => doc,
             Err(err) => {
-                warn!(?path, ?err, "failed to load config");
+                warn!(?path, %err, "failed to load config");
                 Document::new()
             }
         };
@@ -127,7 +127,7 @@ impl FileStorage {
         let mut doc = match self.load_document(path).await {
             Ok(doc) => doc,
             Err(err) => {
-                warn!(?path, ?err, "failed to load config");
+                warn!(?path, %err, "failed to load config");
                 Document::new()
             }
         };
@@ -168,7 +168,7 @@ impl FileStorage {
         let mut doc = match self.load_document(path).await {
             Ok(doc) => doc,
             Err(err) => {
-                warn!(?path, ?err, "failed to load config");
+                warn!(?path, %err, "failed to load config");
                 Document::new()
             }
         };
@@ -187,7 +187,7 @@ impl FileStorage {
         let mut doc = match self.load_document(path).await {
             Ok(doc) => doc,
             Err(err) => {
-                warn!(?path, ?err, "failed to load config");
+                warn!(?path, %err, "failed to load config");
                 Document::new()
             }
         };
@@ -309,7 +309,7 @@ impl FileStorage {
         let accounts = match self.load_accounts().await {
             Ok(accounts) => accounts,
             Err(err) => {
-                error!(?err, "failed to load accounts: {err}");
+                error!(%err, "failed to load accounts: {err}");
                 return Err(Error::InvalidLoginCredentials);
             }
         };
@@ -317,7 +317,7 @@ impl FileStorage {
         let account = match accounts.get(name) {
             Some(account) => account,
             None => {
-                error!(?name, "account not found: {name}");
+                error!(%name, "account not found: {name}");
                 return Err(Error::InvalidLoginCredentials);
             }
         };
@@ -325,14 +325,14 @@ impl FileStorage {
         let parsed_hash = match PasswordHash::new(&account.password) {
             Ok(parsed_hash) => parsed_hash,
             Err(err) => {
-                error!(?err, "failed to parse password hash: {err}");
+                error!(%err, "failed to parse password hash: {err}");
                 return Err(Error::InvalidLoginCredentials);
             }
         };
 
         let argon2 = Argon2::default();
         if let Err(err) = argon2.verify_password(password.as_bytes(), &parsed_hash) {
-            error!(?err, "failed to verify password: {err}");
+            error!(%err, "failed to verify password: {err}");
             return Err(Error::InvalidLoginCredentials);
         }
 
@@ -347,7 +347,7 @@ impl FileStorage {
         let accounts = match self.load_accounts().await {
             Ok(accounts) => accounts,
             Err(err) => {
-                error!(?err, "failed to load accounts: {err}");
+                error!(%err, "failed to load accounts: {err}");
                 return Err(Error::InvalidLoginCredentials);
             }
         };
@@ -355,7 +355,7 @@ impl FileStorage {
         let account = match accounts.get(name) {
             Some(account) => account,
             None => {
-                error!(?name, "account not found: {name}");
+                error!(%name, "account not found: {name}");
                 return Err(Error::InvalidLoginCredentials);
             }
         };
@@ -365,7 +365,7 @@ impl FileStorage {
                 .to_bytes()
                 .map_err(|_| Error::InvalidLoginCredentials)?,
             None => {
-                error!(?name, "totp not found: {name}");
+                error!(%name, "totp not found: {name}");
                 return Err(Error::InvalidLoginCredentials);
             }
         };

--- a/taxy/src/proxy/http/mod.rs
+++ b/taxy/src/proxy/http/mod.rs
@@ -60,7 +60,12 @@ pub struct HttpPortContext {
 
 impl HttpPortContext {
     pub fn new(entry: &PortEntry) -> Result<Self, Error> {
-        let span = span!(Level::INFO, "proxy", resource_id = entry.id.to_string(), listen = ?entry.port.listen);
+        let span = span!(
+            Level::INFO,
+            "proxy",
+            resource_id = entry.id.to_string(),
+            listen = %entry.port.listen
+        );
         let enter = span.clone();
         let _enter = enter.enter();
 

--- a/taxy/src/proxy/tcp.rs
+++ b/taxy/src/proxy/tcp.rs
@@ -33,7 +33,7 @@ pub struct TcpPortContext {
 
 impl TcpPortContext {
     pub fn new(entry: &PortEntry) -> Result<Self, Error> {
-        let span = span!(Level::INFO, "proxy", resource_id = entry.id.to_string(), listen = ?entry.port.listen);
+        let span = span!(Level::INFO, "proxy", resource_id = entry.id.to_string(), listen = %entry.port.listen);
         let enter = span.clone();
         let _enter = enter.enter();
 

--- a/taxy/src/server/state.rs
+++ b/taxy/src/server/state.rs
@@ -73,7 +73,7 @@ impl ServerState {
                     ports.update(ctx);
                 }
                 Err(err) => {
-                    error!(?err, "failed to create proxy state");
+                    error!(%err, "failed to create proxy state");
                 }
             };
         }
@@ -260,7 +260,7 @@ impl ServerState {
                 .await
             {
                 span.in_scope(|| {
-                    error!(?err, "failed to setup port");
+                    error!(%err, "failed to setup port");
                 });
             }
         }
@@ -268,7 +268,7 @@ impl ServerState {
 
     pub async fn run_background_tasks(&mut self, app_info: &AppInfo) {
         if let Err(err) = self.cleanup_old_logs(app_info).await {
-            error!(?err, "failed to cleanup old logs");
+            error!(%err, "failed to cleanup old logs");
         }
 
         self.start_http_challenges().await;
@@ -292,7 +292,7 @@ impl ServerState {
         }
         for id in &removing_items {
             if let Err(err) = self.certs.delete(*id) {
-                error!(?err, "failed to delete cert");
+                error!(%err, "failed to delete cert");
             }
         }
         if !removing_items.is_empty() {
@@ -398,7 +398,7 @@ impl ServerState {
                     }
                     Err(err) => {
                         let _enter = span.enter();
-                        error!(?err, "failed to start challenge");
+                        error!(%err, "failed to start challenge");
                     }
                 }
             }


### PR DESCRIPTION
This pull request updates the code to use the % sigil instead of the ? sigil in the error logging statements. 