### PR TITLE
Show acme renewal date on WebUI

### DIFF
--- a/taxy-api/src/acme.rs
+++ b/taxy-api/src/acme.rs
@@ -49,6 +49,7 @@ pub struct AcmeInfo {
     pub identifiers: Vec<String>,
     #[schema(value_type = String, example = "http-01")]
     pub challenge_type: String,
+    pub next_renewal: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, ToSchema)]

--- a/taxy-webui/src/format.rs
+++ b/taxy-webui/src/format.rs
@@ -3,7 +3,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use wasm_bindgen::UnwrapThrowExt;
 use web_time::{Duration, SystemTime, UNIX_EPOCH};
 
-pub fn format_expiry(unix_time: i64) -> String {
+pub fn format_time(unix_time: i64) -> String {
     let time = OffsetDateTime::from_unix_timestamp(unix_time).unwrap_throw();
     let timestamp = time.format(&Rfc3339).unwrap_throw();
     let date = timestamp.split('T').next().unwrap_throw().to_string();

--- a/taxy-webui/src/pages/cert_list.rs
+++ b/taxy-webui/src/pages/cert_list.rs
@@ -1,5 +1,5 @@
 use crate::auth::use_ensure_auth;
-use crate::format::format_expiry;
+use crate::format::format_time;
 use crate::pages::Route;
 use crate::store::{AcmeStore, CertStore};
 use crate::API_ENDPOINT;
@@ -210,7 +210,7 @@ pub fn cert_list() -> Html {
                                         {entry.id.to_string()}
                                     </td>
                                     <td class="px-4 py-4">
-                                        {format_expiry(entry.not_after)}
+                                        {format_time(entry.not_after)}
                                     </td>
                                     <td class="px-4 py-4 w-0 whitespace-nowrap" align="right">
                                         <a class="cursor-pointer font-medium text-blue-600 dark:text-blue-400 hover:underline mr-5" onclick={download_onclick}>{"Download"}</a>
@@ -289,7 +289,7 @@ pub fn cert_list() -> Html {
                                     }
                                 </td>
                                 <td class="px-4 py-4">
-                                    {format_expiry(entry.not_after)}
+                                    {format_time(entry.not_after)}
                                 </td>
                                 <td class="px-4 py-4 w-0 whitespace-nowrap" align="right">
                                     <a class="cursor-pointer font-medium text-blue-600 dark:text-blue-400 hover:underline mr-5" onclick={download_onclick}>{"Download"}</a>
@@ -320,6 +320,9 @@ pub fn cert_list() -> Html {
                             </th>
                             <th scope="col" class="px-4 py-3">
                                 {"Provider"}
+                            </th>
+                            <th scope="col" class="px-4 py-3">
+                                {"Renews on"}
                             </th>
                             <th scope="col" class="px-4 py-3" align="center">
                                 {"Active"}
@@ -365,6 +368,11 @@ pub fn cert_list() -> Html {
                                 </td>
                                 <td class="px-4 py-4">
                                     {provider}
+                                </td>
+                                <td class="px-4 py-4">
+                                    if let Some(time) = entry.next_renewal {
+                                        { format_time(time) }
+                                    }
                                 </td>
                                 <td class="px-4 py-4 w-0 whitespace-nowrap" align="center">
                                     <label class="relative inline-flex items-center cursor-pointer mt-1">

--- a/taxy/src/server/rpc/acme.rs
+++ b/taxy/src/server/rpc/acme.rs
@@ -13,7 +13,11 @@ impl RpcMethod for GetAcmeList {
     type Output = Vec<AcmeInfo>;
 
     async fn call(self, state: &mut ServerState) -> Result<Self::Output, Error> {
-        Ok(state.acmes.entries().map(|acme| acme.info()).collect())
+        Ok(state
+            .acmes
+            .entries()
+            .map(|acme| acme.info(&state.certs))
+            .collect())
     }
 }
 
@@ -29,7 +33,7 @@ impl RpcMethod for GetAcme {
         state
             .acmes
             .get(self.id)
-            .map(|acme| acme.info())
+            .map(|acme| acme.info(&state.certs))
             .ok_or(Error::IdNotFound {
                 id: self.id.to_string(),
             })


### PR DESCRIPTION
This pull request adds a new field, `next_renewal`, to the `AcmeInfo` struct in order to store the next renewal date for each ACME entry. This information is used to display the renewal date on the AcmeList page.