### PR TITLE
Use insecure cookie automatically on HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,6 @@ $ taxy start
 
 Once the server is running, you can access the admin panel at [http://localhost:46492/](http://localhost:46492/).
 
-WebUI uses [`Secure`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure) cookie attribute to store the session token. This means that the WebUI will only work over HTTPS, unless it is served on localhost (although certain browsers, like Safari, may deny this even on localhost). If you want to use the WebUI over HTTP, you can use the `--insecure-webui` command-line option.
-
-```bash
-$ taxy start --insecure-webui
-```
-
 ## Development
 
 To contribute or develop Taxy, follow these steps:

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -122,8 +122,6 @@ $ taxy start
 Once the server is running, you can access the admin panel at [http://localhost:46492/](http://localhost:46492/).
 
 > To ensure the security of your server's admin panel, it is highly recommended to employ SSH port forwarding when running the server on a remote machine. This practice prevents exposing the admin panel's port to the public, as the connection is in plain HTTP and lacks encryption. However, you have the option to serve the admin panel via HTTPS using Taxy later on.
->
-> Please note that the WebUI relies on the Secure cookie attribute to store the session token. Consequently, the WebUI will only function over HTTPS unless it's being served on localhost. It's worth mentioning that some browsers, such as Safari, may still block it even on localhost. If you intend to use the WebUI over HTTP, you can utilize the `--insecure-webui` command-line option.
 
 # Tutorial
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -76,8 +76,6 @@ If needed, these files can be edited manually. Note, however, that Taxy does not
 
 Taxy includes a built-in WebUI. By default, it is served on localhost:46492. However, you can customize the port using the `TAXY_WEBUI` environment variable or the `--webui` command-line option. If you wish to disable the WebUI, set the `TAXY_NO_WEBUI=1` environment variable or use the `--no-webui` command-line option.
 
-WebUI uses [`Secure`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#secure) cookie attribute to store the session token. This means that the WebUI will only work over HTTPS, unless it is served on localhost (although certain browsers, like Safari, may deny this even on localhost). If you want to use the WebUI over HTTP, you can set the `TAXY_INSECURE_WEBUI=1` environment variable or use the `--insecure-webui` command-line option. Note that this is not recommended.
-
 # Logging
 
 Taxy logs to the standard output as its default setting. You can change this behavior by setting the `TAXY_LOG`, `TAXY_ACCESS_LOG` environment variable or using the `--log`, `--access-log` command-line option.

--- a/taxy-api/src/auth.rs
+++ b/taxy-api/src/auth.rs
@@ -16,6 +16,8 @@ pub struct LoginRequest {
     #[schema(inline)]
     #[serde(flatten)]
     pub method: LoginMethod,
+    #[serde(default)]
+    pub insecure: bool,
 }
 
 #[derive(Deserialize, Serialize, ToSchema)]

--- a/taxy-webui/src/pages/login.rs
+++ b/taxy-webui/src/pages/login.rs
@@ -115,10 +115,15 @@ pub fn login() -> Html {
         };
 
         wasm_bindgen_futures::spawn_local(async move {
+            let insecure = web_sys::window()
+                .and_then(|window| window.location().protocol().ok())
+                .unwrap_or_default()
+                != "https:";
             let login: ApiResult<LoginResponse> = Request::post(&format!("{API_ENDPOINT}/login"))
                 .json(&LoginRequest {
                     username: username.to_string(),
                     method,
+                    insecure,
                 })
                 .unwrap()
                 .send()

--- a/taxy/src/admin/auth.rs
+++ b/taxy/src/admin/auth.rs
@@ -66,6 +66,7 @@ pub async fn login(
         }
     }
 
+    let insecure = request.insecure || state.data.lock().await.insecure;
     let result = state.call(VerifyAccount { request }).await;
     match result {
         Err(err) => Err(warp::reject::custom(err)),
@@ -74,7 +75,6 @@ pub async fn login(
                 LoginResponse::Success => SessionKind::Admin,
                 _ => SessionKind::Login,
             };
-            let insecure = state.data.lock().await.insecure;
             let secure_cookie = if insecure { "" } else { "Secure" };
             Ok(warp::reply::with_header(
                 warp::reply::json(&res),


### PR DESCRIPTION
This pull request updates the WebUI to use an insecure cookie automatically when served over HTTP. Previously, the WebUI required the `--insecure-webui` command-line option to be used. This change ensures that the WebUI can be accessed over HTTP without the need for additional configuration.