### PR TITLE
Fix path matching in RequestFilter

### DIFF
--- a/taxy/src/proxy/http/filter.rs
+++ b/taxy/src/proxy/http/filter.rs
@@ -43,14 +43,14 @@ impl RequestFilter {
         if !host_matched && !self.vhosts.is_empty() {
             return None;
         }
-        let path = req.uri().path().split('/');
+        let path = req.uri().path().trim_start_matches('/').split('/');
         let count = path
             .clone()
             .zip(self.path.iter())
             .take_while(|(a, b)| a == b)
             .count();
         if count == self.path.len() {
-            let new_path = path.skip(count).collect::<Vec<_>>().join("/");
+            let new_path = "/".to_string() + &path.skip(count).collect::<Vec<_>>().join("/");
             FilterResult::new(&new_path).ok()
         } else {
             None


### PR DESCRIPTION
This pull request fixes the path matching in the RequestFilter implementation. Previously, the path was not correctly trimmed and joined, resulting in incorrect matching. This PR ensures that the path is properly trimmed and joined with a leading slash.