### PR TITLE
Remove --insecure-webui option

### DIFF
--- a/taxy/src/admin/auth.rs
+++ b/taxy/src/admin/auth.rs
@@ -66,7 +66,7 @@ pub async fn login(
         }
     }
 
-    let insecure = request.insecure || state.data.lock().await.insecure;
+    let secure_cookie = if request.insecure { "" } else { "Secure" };
     let result = state.call(VerifyAccount { request }).await;
     match result {
         Err(err) => Err(warp::reject::custom(err)),
@@ -75,7 +75,6 @@ pub async fn login(
                 LoginResponse::Success => SessionKind::Admin,
                 _ => SessionKind::Login,
             };
-            let secure_cookie = if insecure { "" } else { "Secure" };
             Ok(warp::reply::with_header(
                 warp::reply::json(&res),
                 "Set-Cookie",

--- a/taxy/src/admin/mod.rs
+++ b/taxy/src/admin/mod.rs
@@ -40,12 +40,11 @@ mod swagger;
 pub async fn start_admin(
     app_info: AppInfo,
     addr: SocketAddr,
-    insecure: bool,
     command: mpsc::Sender<ServerCommand>,
     mut callback: mpsc::Receiver<RpcCallback>,
     event: broadcast::Sender<ServerEvent>,
 ) -> anyhow::Result<()> {
-    let data = Data::new(app_info, insecure).await?;
+    let data = Data::new(app_info).await?;
     let data = Arc::new(Mutex::new(data));
     let app_state = AppState {
         sender: command,
@@ -222,7 +221,6 @@ struct Data {
     config: AppConfig,
     sessions: SessionStore,
     log: Arc<LogReader>,
-    insecure: bool,
 
     rpc_counter: usize,
     rpc_callbacks: HashMap<usize, oneshot::Sender<CallbackData>>,
@@ -260,11 +258,10 @@ impl AppState {
 }
 
 impl Data {
-    async fn new(app_info: AppInfo, insecure: bool) -> anyhow::Result<Self> {
+    async fn new(app_info: AppInfo) -> anyhow::Result<Self> {
         let log = app_info.log_path.join("log.db");
         Ok(Self {
             app_info,
-            insecure,
             config: AppConfig::default(),
             sessions: Default::default(),
             log: Arc::new(LogReader::new(&log).await?),

--- a/taxy/src/args.rs
+++ b/taxy/src/args.rs
@@ -64,9 +64,6 @@ pub struct StartArgs {
     #[clap(long, short, env = "TAXY_NO_WEBUI", conflicts_with = "webui")]
     pub no_webui: bool,
 
-    #[clap(long, env = "TAXY_INSECURE_WEBUI", conflicts_with = "no_webui")]
-    pub insecure_webui: bool,
-
     #[clap(long, short, value_name = "DIR", env = "TAXY_CONFIG_DIR")]
     pub config_dir: Option<PathBuf>,
 

--- a/taxy/src/main.rs
+++ b/taxy/src/main.rs
@@ -68,7 +68,7 @@ async fn start(args: StartArgs) -> anyhow::Result<()> {
 
     let webui_enabled = !args.no_webui;
     tokio::select! {
-        r = taxy::admin::start_admin(app_info, args.webui, args.insecure_webui, channels.command, channels.callback, channels.event), if webui_enabled => {
+        r = taxy::admin::start_admin(app_info, args.webui, channels.command, channels.callback, channels.event), if webui_enabled => {
             if let Err(err) = r {
                 error!("admin error: {}", err);
             }


### PR DESCRIPTION
This pull request removes the --insecure-webui option from the codebase. The option was no longer needed and was causing unnecessary complexity.