### PR TITLE
acme: fix requests not triggered without old certs

### DIFF
--- a/taxy/src/server/state.rs
+++ b/taxy/src/server/state.rs
@@ -314,12 +314,13 @@ impl ServerState {
     async fn start_http_challenges(&mut self) {
         let entries = self.acmes.entries().cloned();
         let entries = entries
+            .filter(|entry| entry.acme.config.active)
             .filter(|entry| {
-                entry.acme.config.active
-                    && entry
-                        .next_renewal(&self.certs)
-                        .map(|next| next.elapsed().is_ok())
-                        .unwrap_or_default()
+                if let Some(next) = entry.next_renewal(&self.certs) {
+                    next.elapsed().is_ok()
+                } else {
+                    true
+                }
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
This pull request fixes an issue where HTTP challenges were not being triggered without old certificates. 