### PR TITLE
Preserve original HOST header value in HTTP requests

### DIFF
--- a/taxy/src/proxy/http/mod.rs
+++ b/taxy/src/proxy/http/mod.rs
@@ -280,11 +280,7 @@ async fn start(
                     "https" | "wss" => Scheme::HTTPS,
                     _ => Scheme::HTTP,
                 });
-
-                let authority = server.authority.clone();
-                req.headers_mut()
-                    .insert(HOST, HeaderValue::from_str(authority.as_str()).unwrap());
-                parts.authority = Some(authority);
+                parts.authority = Some(server.authority.clone());
             }
 
             if let Ok(uri) = Uri::from_parts(parts) {


### PR DESCRIPTION
This pull request includes a change to preserve the original HOST header value in HTTP requests. The previous implementation was sending a modified HOST header value, but now it will preserve the original value.