### PR TITLE
Update serde_qs to version 0.13.0 and brotli to version 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
 dependencies = [
- "brotli",
+ "brotli 3.3.4",
  "flate2",
  "futures-core",
  "memchr",
@@ -348,7 +348,18 @@ checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 2.3.4",
+]
+
+[[package]]
+name = "brotli"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 4.0.0",
 ]
 
 [[package]]
@@ -356,6 +367,16 @@ name = "brotli-decompressor"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -3274,7 +3295,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base64 0.22.0",
- "brotli",
+ "brotli 5.0.0",
  "built",
  "clap",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
 dependencies = [
  "percent-encoding",
  "serde",

--- a/taxy/Cargo.toml
+++ b/taxy/Cargo.toml
@@ -57,7 +57,7 @@ serde = { version = "1.0.171", features = ["rc"] }
 serde_default = "0.1.0"
 serde_derive = "1.0.171"
 serde_json = "1.0.102"
-serde_qs = "0.12.0"
+serde_qs = "0.13.0"
 sha2 = "0.10.7"
 shellexpand = "3.1.0"
 sqlx = { version = "0.7.0", features = [

--- a/taxy/Cargo.toml
+++ b/taxy/Cargo.toml
@@ -25,7 +25,7 @@ argon2 = "0.5.0"
 async-trait = "0.1.71"
 backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.22.0"
-brotli = "3.3.4"
+brotli = "5.0.0"
 clap = { version = "4.3.11", features = ["derive", "env"] }
 dashmap = "5.5.0"
 directories = "5.0.1"


### PR DESCRIPTION
This pull request updates the serde_qs crate to version 0.13.0 and the brotli crate to version 5.0.0. These updates include bug fixes and improvements to the functionality of the crates.