### PR TITLE
Update network-interface version to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296ae2183dab440e352740b1fcf0589d8058afa40bc29fd163227ddb01fbf539"
+checksum = "433419f898328beca4f2c6c73a1b52540658d92b0a99f0269330457e0fd998d5"
 dependencies = [
  "cc",
  "libc",

--- a/taxy/Cargo.toml
+++ b/taxy/Cargo.toml
@@ -41,7 +41,7 @@ indexmap = { version = "2.0.0", features = ["serde"] }
 instant-acme = "0.4.0"
 log = "0.4.19"
 mime_guess = "2.0.4"
-network-interface = "1.0.1"
+network-interface = "2.0.0"
 once_cell = "1.18.0"
 percent-encoding = "2.3.0"
 phf = { version = "0.11.2", features = ["macros"] }


### PR DESCRIPTION
This pull request updates the network-interface version from 1.0.1 to 2.0.0.