### PR TITLE
Fix server URL validation and ignore invalid routes

### DIFF
--- a/taxy-api/src/error.rs
+++ b/taxy-api/src/error.rs
@@ -1,6 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
-use url::Url;
 use utoipa::ToSchema;
 
 use crate::{id::ShortId, multiaddr::Multiaddr};
@@ -31,7 +30,7 @@ pub enum Error {
     InvalidSubjectName { name: String },
 
     #[error("invalid server url: {url}")]
-    InvalidServerUrl { url: Url },
+    InvalidServerUrl { url: String },
 
     #[error("invalid multiaddr: {addr}")]
     InvalidMultiaddr { addr: String },

--- a/taxy-api/src/proxy.rs
+++ b/taxy-api/src/proxy.rs
@@ -1,9 +1,14 @@
+use std::fmt;
+use std::str::FromStr;
+
+use crate::error::Error;
 use crate::subject_name::SubjectName;
 use crate::{id::ShortId, port::UpstreamServer};
 use serde_default::DefaultFromSerde;
 use serde_derive::{Deserialize, Serialize};
 use url::Url;
 use utoipa::ToSchema;
+use warp::filters::host::Authority;
 
 #[derive(Debug, DefaultFromSerde, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct Proxy {
@@ -101,5 +106,67 @@ fn default_route_path() -> String {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct Server {
     #[schema(value_type = String, example = "https://example.com/api")]
-    pub url: Url,
+    pub url: ServerUrl,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(transparent)]
+pub struct ServerUrl(Url);
+
+impl ServerUrl {
+    pub fn hostname(&self) -> Option<&str> {
+        self.0.host_str()
+    }
+
+    pub fn authority(&self) -> Option<Authority> {
+        format!(
+            "{}:{}",
+            self.hostname()?,
+            self.0.port_or_known_default().unwrap_or_default()
+        )
+        .parse()
+        .ok()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ServerUrl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let url = String::deserialize(deserializer)?;
+        ServerUrl::from_str(&url).map_err(serde::de::Error::custom)
+    }
+}
+
+impl From<ServerUrl> for Url {
+    fn from(url: ServerUrl) -> Self {
+        url.0
+    }
+}
+
+impl FromStr for ServerUrl {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Url::from_str(s)
+            .ok()
+            .map(ServerUrl)
+            .filter(|url| url.authority().is_some())
+            .ok_or_else(|| Error::InvalidServerUrl { url: s.into() })
+    }
+}
+
+impl TryFrom<Url> for ServerUrl {
+    type Error = url::ParseError;
+
+    fn try_from(url: Url) -> Result<Self, Self::Error> {
+        Ok(ServerUrl(url))
+    }
+}
+
+impl fmt::Display for ServerUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }

--- a/taxy-webui/src/components/http_proxy_config.rs
+++ b/taxy-webui/src/components/http_proxy_config.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use taxy_api::proxy::{HttpProxy, Route, Server};
+use taxy_api::proxy::{HttpProxy, Route, Server, ServerUrl};
 use taxy_api::subject_name::SubjectName;
-use url::Url;
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
@@ -159,7 +158,7 @@ fn get_proxy(
         let servers = route.1.clone();
         let mut urls = Vec::new();
         for url in servers {
-            match Url::from_str(&url) {
+            match ServerUrl::from_str(&url) {
                 Ok(url) => urls.push(Server { url }),
                 Err(err) => {
                     errors.insert(format!("routes_{}", i), err.to_string());

--- a/taxy/src/proxy/http/route.rs
+++ b/taxy/src/proxy/http/route.rs
@@ -94,28 +94,19 @@ impl TryFrom<Server> for ParsedServer {
     type Error = Error;
 
     fn try_from(server: Server) -> Result<Self, Self::Error> {
-        let hostname = server
-            .url
-            .host_str()
-            .ok_or_else(|| Error::InvalidServerUrl {
-                url: server.url.clone(),
-            })?;
-        let authority = format!(
-            "{}:{}",
-            hostname,
-            server.url.port_or_known_default().unwrap_or_default()
-        )
-        .parse()
-        .map_err(|_| Error::InvalidServerUrl {
-            url: server.url.clone(),
+        let authority = server.url.authority().ok_or(Error::InvalidServerUrl {
+            url: server.url.to_string(),
+        })?;
+        let hostname = server.url.hostname().ok_or(Error::InvalidServerUrl {
+            url: server.url.to_string(),
         })?;
         let server_name = ServerName::try_from(hostname)
             .map_err(|_| Error::InvalidServerUrl {
-                url: server.url.clone(),
+                url: server.url.to_string(),
             })?
             .to_owned();
         Ok(Self {
-            url: server.url,
+            url: server.url.into(),
             authority,
             server_name,
         })

--- a/taxy/tests/https_test.rs
+++ b/taxy/tests/https_test.rs
@@ -51,7 +51,7 @@ async fn https_proxy() -> anyhow::Result<()> {
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
-                            url: listen_port.https_url("/"),
+                            url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
                 }),
@@ -147,7 +147,7 @@ async fn https_proxy_invalid_cert() -> anyhow::Result<()> {
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
-                            url: listen_port.https_url("/"),
+                            url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
                 }),
@@ -224,7 +224,7 @@ async fn https_proxy_automatic_upgrade() -> anyhow::Result<()> {
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
-                            url: listen_port.https_url("/"),
+                            url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
                 }),
@@ -316,7 +316,7 @@ async fn https_proxy_domain_fronting() -> anyhow::Result<()> {
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
-                            url: listen_port.https_url("/"),
+                            url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
                 }),

--- a/taxy/tests/ws_test.rs
+++ b/taxy/tests/ws_test.rs
@@ -50,7 +50,7 @@ async fn ws_proxy() -> anyhow::Result<()> {
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
-                            url: listen_port.http_url("/"),
+                            url: listen_port.http_url("/").try_into().unwrap(),
                         }],
                     }],
                 }),

--- a/taxy/tests/wss_test.rs
+++ b/taxy/tests/wss_test.rs
@@ -65,7 +65,7 @@ async fn wss_proxy() -> anyhow::Result<()> {
                     routes: vec![Route {
                         path: "/".into(),
                         servers: vec![taxy_api::proxy::Server {
-                            url: listen_port.https_url("/"),
+                            url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
                 }),


### PR DESCRIPTION
This pull request fixes an issue with server URL validation in the API. Previously, the code was using the `Url` type for server URLs, but it has been updated to use a new `ServerUrl` type instead. The `ServerUrl` type ensures that the URL is valid and includes a valid authority. Additionally, the code now ignores invalid routes in the `Router::new` function. These changes improve the overall reliability and robustness of the API.