### PR TITLE
Fix clippy warnings

### DIFF
--- a/taxy-api/src/log.rs
+++ b/taxy-api/src/log.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 use time::OffsetDateTime;
 use utoipa::{IntoParams, ToSchema};
 
@@ -28,14 +28,14 @@ impl TryFrom<u8> for LogLevel {
     }
 }
 
-impl ToString for LogLevel {
-    fn to_string(&self) -> String {
+impl Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LogLevel::Error => "error".to_string(),
-            LogLevel::Warn => "warn".to_string(),
-            LogLevel::Info => "info".to_string(),
-            LogLevel::Debug => "debug".to_string(),
-            LogLevel::Trace => "trace".to_string(),
+            LogLevel::Error => write!(f, "error"),
+            LogLevel::Warn => write!(f, "warn"),
+            LogLevel::Info => write!(f, "info"),
+            LogLevel::Debug => write!(f, "debug"),
+            LogLevel::Trace => write!(f, "trace"),
         }
     }
 }

--- a/taxy-api/src/proxy.rs
+++ b/taxy-api/src/proxy.rs
@@ -1,14 +1,12 @@
-use std::fmt;
-use std::str::FromStr;
-
 use crate::error::Error;
 use crate::subject_name::SubjectName;
 use crate::{id::ShortId, port::UpstreamServer};
 use serde_default::DefaultFromSerde;
 use serde_derive::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 use url::Url;
 use utoipa::ToSchema;
-use warp::filters::host::Authority;
 
 #[derive(Debug, DefaultFromSerde, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct Proxy {
@@ -118,14 +116,12 @@ impl ServerUrl {
         self.0.host_str()
     }
 
-    pub fn authority(&self) -> Option<Authority> {
-        format!(
+    pub fn authority(&self) -> Option<String> {
+        Some(format!(
             "{}:{}",
             self.hostname()?,
             self.0.port_or_known_default().unwrap_or_default()
-        )
-        .parse()
-        .ok()
+        ))
     }
 }
 

--- a/taxy-api/src/subject_name.rs
+++ b/taxy-api/src/subject_name.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use serde::{Deserialize, Serialize};
-use std::{net::IpAddr, str::FromStr};
+use std::{fmt::Display, net::IpAddr, str::FromStr};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubjectName {
@@ -44,12 +44,12 @@ impl<'de> Deserialize<'de> for SubjectName {
     }
 }
 
-impl ToString for SubjectName {
-    fn to_string(&self) -> String {
+impl Display for SubjectName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::DnsName(name) => name.to_owned(),
-            Self::WildcardDnsName(name) => format!("*.{}", name),
-            Self::IPAddress(addr) => addr.to_string(),
+            Self::DnsName(name) => write!(f, "{}", name),
+            Self::WildcardDnsName(name) => write!(f, "*.{}", name),
+            Self::IPAddress(addr) => write!(f, "{}", addr),
         }
     }
 }

--- a/taxy-webui/src/components/proxy_config.rs
+++ b/taxy-webui/src/components/proxy_config.rs
@@ -4,6 +4,7 @@ use crate::store::PortStore;
 use crate::API_ENDPOINT;
 use gloo_net::http::Request;
 use std::collections::HashMap;
+use std::fmt::Display;
 use taxy_api::id::ShortId;
 use taxy_api::proxy::{HttpProxy, ProxyKind, TcpProxy};
 use taxy_api::{port::PortEntry, proxy::Proxy};
@@ -18,11 +19,11 @@ pub enum ProxyProtocol {
     Tcp,
 }
 
-impl ToString for ProxyProtocol {
-    fn to_string(&self) -> String {
+impl Display for ProxyProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProxyProtocol::Http => "HTTP / HTTPS".to_string(),
-            ProxyProtocol::Tcp => "TCP / TCP over TLS".to_string(),
+            ProxyProtocol::Http => write!(f, "HTTP / HTTPS"),
+            ProxyProtocol::Tcp => write!(f, "TCP / TCP over TLS"),
         }
     }
 }

--- a/taxy-webui/src/pages/cert_list.rs
+++ b/taxy-webui/src/pages/cert_list.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::auth::use_ensure_auth;
 use crate::format::format_duration;
 use crate::pages::Route;
@@ -27,14 +29,13 @@ pub struct CertsQuery {
     pub tab: CertsTab,
 }
 
-impl ToString for CertsTab {
-    fn to_string(&self) -> String {
+impl Display for CertsTab {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CertsTab::Server => "Server Certs",
-            CertsTab::Root => "Root Certs",
-            CertsTab::Acme => "ACME",
+            CertsTab::Server => write!(f, "Server Certs"),
+            CertsTab::Root => write!(f, "Root Certs"),
+            CertsTab::Acme => write!(f, "ACME"),
         }
-        .into()
     }
 }
 

--- a/taxy-webui/src/pages/new_acme.rs
+++ b/taxy-webui/src/pages/new_acme.rs
@@ -4,6 +4,7 @@ use crate::pages::cert_list::{CertsQuery, CertsTab};
 use crate::{auth::use_ensure_auth, pages::Route, API_ENDPOINT};
 use gloo_net::http::Request;
 use std::collections::HashMap;
+use std::fmt::Display;
 use taxy_api::acme::AcmeRequest;
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use web_sys::HtmlSelectElement;
@@ -35,13 +36,13 @@ impl Provider {
     }
 }
 
-impl ToString for Provider {
-    fn to_string(&self) -> String {
+impl Display for Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Provider::LetsEncrypt => "Let's Encrypt".to_string(),
-            Provider::GoogleTrustServices => "Google Trust Services".to_string(),
-            Provider::ZeroSSL => "ZeroSSL".to_string(),
-            Provider::Custom => "Custom".to_string(),
+            Provider::LetsEncrypt => write!(f, "Let's Encrypt"),
+            Provider::GoogleTrustServices => write!(f, "Google Trust Services"),
+            Provider::ZeroSSL => write!(f, "ZeroSSL"),
+            Provider::Custom => write!(f, "Custom"),
         }
     }
 }

--- a/taxy/src/proxy/http/route.rs
+++ b/taxy/src/proxy/http/route.rs
@@ -1,5 +1,6 @@
 use super::filter::{FilterResult, RequestFilter};
 use hyper::Request;
+use std::str::FromStr;
 use taxy_api::{
     error::Error,
     id::ShortId,
@@ -88,6 +89,7 @@ impl TryFrom<Server> for ParsedServer {
     type Error = Error;
 
     fn try_from(server: Server) -> Result<Self, Self::Error> {
+        let url = server.url.clone().into();
         let authority = server.url.authority().ok_or(Error::InvalidServerUrl {
             url: server.url.to_string(),
         })?;
@@ -95,8 +97,10 @@ impl TryFrom<Server> for ParsedServer {
             url: server.url.to_string(),
         })?;
         Ok(Self {
-            url: server.url.into(),
-            authority,
+            url,
+            authority: Authority::from_str(&authority).map_err(|_| Error::InvalidServerUrl {
+                url: hostname.to_owned(),
+            })?,
         })
     }
 }


### PR DESCRIPTION
This pull request fixes clippy warnings in the codebase. The changes include implementing the `Display` trait instead of the `ToString` trait for certain types, removing unused imports, and refactoring code to improve readability.