### PR TITLE
Send both forwarded and x-forwarded-for headers by default

### DIFF
--- a/taxy/src/proxy/http/mod.rs
+++ b/taxy/src/proxy/http/mod.rs
@@ -103,7 +103,6 @@ impl HttpPortContext {
             router: Router::new(proxies),
             header_rewriter: HeaderRewriter::builder()
                 .trust_upstream_headers(false)
-                .use_std_forwarded(true)
                 .set_via(HeaderValue::from_static("taxy"))
                 .build(),
         }));

--- a/taxy/tests/http_test.rs
+++ b/taxy/tests/http_test.rs
@@ -16,8 +16,6 @@ async fn http_proxy() -> anyhow::Result<()> {
     let mock_get = server
         .mock("GET", "/hello?world=1")
         .match_header("via", "taxy")
-        .match_header("x-forwarded-for", mockito::Matcher::Missing)
-        .match_header("x-forwarded-host", mockito::Matcher::Missing)
         .match_header("x-real-ip", mockito::Matcher::Missing)
         .match_header("x-forwarded-proto", "http")
         .match_header("accept-encoding", "gzip, br")
@@ -28,8 +26,6 @@ async fn http_proxy() -> anyhow::Result<()> {
     let mock_get_with_path = server
         .mock("GET", "/Hello?world=1")
         .match_header("via", "taxy")
-        .match_header("x-forwarded-for", mockito::Matcher::Missing)
-        .match_header("x-forwarded-host", mockito::Matcher::Missing)
         .match_header("x-real-ip", mockito::Matcher::Missing)
         .match_header("x-forwarded-proto", "http")
         .match_header("accept-encoding", "gzip, br")
@@ -40,8 +36,6 @@ async fn http_proxy() -> anyhow::Result<()> {
     let mock_get_trailing_slash = server
         .mock("GET", "/hello/?world=1")
         .match_header("via", "taxy")
-        .match_header("x-forwarded-for", mockito::Matcher::Missing)
-        .match_header("x-forwarded-host", mockito::Matcher::Missing)
         .match_header("x-real-ip", mockito::Matcher::Missing)
         .match_header("x-forwarded-proto", "http")
         .match_header("accept-encoding", "gzip, br")
@@ -52,8 +46,6 @@ async fn http_proxy() -> anyhow::Result<()> {
     let mock_post = server
         .mock("POST", "/hello?world=1")
         .match_header("via", "taxy")
-        .match_header("x-forwarded-for", mockito::Matcher::Missing)
-        .match_header("x-forwarded-host", mockito::Matcher::Missing)
         .match_header("x-real-ip", mockito::Matcher::Missing)
         .match_header("x-forwarded-proto", "http")
         .match_header("accept-encoding", "gzip, br")
@@ -67,8 +59,6 @@ async fn http_proxy() -> anyhow::Result<()> {
     let mock_stream = server
         .mock("POST", "/hello?world=1")
         .match_header("via", "taxy")
-        .match_header("x-forwarded-for", mockito::Matcher::Missing)
-        .match_header("x-forwarded-host", mockito::Matcher::Missing)
         .match_header("x-real-ip", mockito::Matcher::Missing)
         .match_header("x-forwarded-proto", "http")
         .match_header("accept-encoding", "gzip, br")


### PR DESCRIPTION
Update the header rewriter to include both `forwarded` and `x-forwarded-for` headers in all requests by default, ensuring proper handling of forwarded IP addresses. Remove the option to use standard forwarded headers. Adjust tests to reflect these changes.

Related to #85