### PR TITLE
Use hickory-resolver for DNS lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1409,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "thiserror 1.0.68",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.68",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1478,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1720,6 +1788,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.6",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +1879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +1911,21 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "md-5"
@@ -2337,6 +2438,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2575,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.3",
+ "hickory-resolver",
  "http 1.0.0",
  "http-body 1.0.0",
  "http-body-util",
@@ -2499,6 +2607,16 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -3417,6 +3535,7 @@ dependencies = [
  "futures",
  "globwalk",
  "hex",
+ "hickory-resolver",
  "humantime-serde",
  "hyper 0.14.27",
  "include_dir",
@@ -4310,6 +4429,12 @@ dependencies = [
  "redox_syscall 0.4.1",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"

--- a/taxy/Cargo.toml
+++ b/taxy/Cargo.toml
@@ -34,6 +34,7 @@ fnv = "1.0.7"
 futures = "0.3.28"
 globwalk = "0.9.1"
 hex = "0.4.3"
+hickory-resolver = { version = "0.24.1", features = ["tokio-runtime", "system-config"] }
 humantime-serde = "1.1.1"
 hyper = { version = "0.14.27", features = ["full"] }
 include_dir = "0.7.3"
@@ -107,6 +108,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
     "json",
     "stream",
     "http2",
+    "hickory-dns",
 ] }
 tokio-tungstenite = { version = "0.21.0", features = [
     "rustls-tls-native-roots",

--- a/taxy/tests/http_test.rs
+++ b/taxy/tests/http_test.rs
@@ -10,7 +10,7 @@ use common::{alloc_port, with_server, TestStorage};
 
 #[tokio::test]
 async fn http_proxy() -> anyhow::Result<()> {
-    let proxy_port = alloc_port()?;
+    let proxy_port = alloc_port().await?;
     let mut server = mockito::Server::new_async().await;
 
     let mock_get = server
@@ -175,7 +175,7 @@ async fn http_proxy() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn http_proxy_dns_error() -> anyhow::Result<()> {
-    let proxy_port = alloc_port()?;
+    let proxy_port = alloc_port().await?;
 
     let config = TestStorage::builder()
         .ports(vec![PortEntry {

--- a/taxy/tests/https_test.rs
+++ b/taxy/tests/https_test.rs
@@ -13,8 +13,8 @@ use common::{alloc_port, with_server, TestStorage};
 
 #[tokio::test]
 async fn https_proxy() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let root = Arc::new(Cert::new_ca().unwrap());
     let cert = Arc::new(Cert::new_self_signed(&["localhost".parse().unwrap()], &root).unwrap());
@@ -109,8 +109,8 @@ async fn https_proxy() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn https_proxy_invalid_cert() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let root = Arc::new(Cert::new_ca().unwrap());
     let cert = Arc::new(Cert::new_self_signed(&["localhost".parse().unwrap()], &root).unwrap());
@@ -186,8 +186,8 @@ async fn https_proxy_invalid_cert() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn https_proxy_automatic_upgrade() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let root = Arc::new(Cert::new_ca().unwrap());
     let cert = Arc::new(Cert::new_self_signed(&["localhost".parse().unwrap()], &root).unwrap());
@@ -278,8 +278,8 @@ async fn https_proxy_automatic_upgrade() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn https_proxy_domain_fronting() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let root = Arc::new(Cert::new_ca().unwrap());
     let cert = Arc::new(Cert::new_self_signed(&["localhost".parse().unwrap()], &root).unwrap());

--- a/taxy/tests/tcp_test.rs
+++ b/taxy/tests/tcp_test.rs
@@ -11,8 +11,8 @@ use common::{alloc_port, with_server, TestStorage};
 
 #[tokio::test]
 async fn tcp_proxy() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let listener = TcpListener::bind(listen_port.socket_addr()).await.unwrap();
     let hello = warp::path!("hello").map(|| "Hello".to_string());

--- a/taxy/tests/tls_test.rs
+++ b/taxy/tests/tls_test.rs
@@ -12,8 +12,8 @@ use common::{alloc_port, with_server, TestStorage};
 
 #[tokio::test]
 async fn tls_proxy() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let root = Arc::new(Cert::new_ca().unwrap());
     let cert = Arc::new(Cert::new_self_signed(&["localhost".parse().unwrap()], &root).unwrap());

--- a/taxy/tests/ws_test.rs
+++ b/taxy/tests/ws_test.rs
@@ -14,8 +14,8 @@ use common::{alloc_port, with_server, TestStorage};
 
 #[tokio::test]
 async fn ws_proxy() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let routes = warp::path("ws").and(warp::ws()).map(|ws: warp::ws::Ws| {
         ws.on_upgrade(|websocket| {

--- a/taxy/tests/wss_test.rs
+++ b/taxy/tests/wss_test.rs
@@ -17,8 +17,8 @@ use common::{alloc_port, with_server, TestStorage};
 
 #[tokio::test]
 async fn wss_proxy() -> anyhow::Result<()> {
-    let listen_port = alloc_port()?;
-    let proxy_port = alloc_port()?;
+    let listen_port = alloc_port().await?;
+    let proxy_port = alloc_port().await?;
 
     let root = Arc::new(Cert::new_ca().unwrap());
     let cert = Arc::new(Cert::new_self_signed(&["localhost".parse().unwrap()], &root).unwrap());


### PR DESCRIPTION
Integrate the hickory-resolver library to enhance DNS resolution within the application, replacing the previous method of hostname resolution. This change improves the consisetncy and reliability of DNS lookups.