### PR TITLE
Redirect HTTP requests to available HTTPS ports by default

### DIFF
--- a/taxy-api/src/proxy.rs
+++ b/taxy-api/src/proxy.rs
@@ -26,10 +26,6 @@ fn default_active() -> bool {
     true
 }
 
-fn is_true(b: &bool) -> bool {
-    *b
-}
-
 fn default_kind() -> ProxyKind {
     ProxyKind::Http(HttpProxy::default())
 }
@@ -54,12 +50,22 @@ pub struct UdpProxy {
     pub upstream_servers: Vec<UpstreamServer>,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, DefaultFromSerde, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct HttpProxy {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schema(value_type = [String], example = json!(["example.com"]))]
     pub vhosts: Vec<SubjectName>,
     pub routes: Vec<Route>,
+    #[serde(default = "upgrade_insecure_default", skip_serializing_if = "is_true")]
+    pub upgrade_insecure: bool,
+}
+
+fn upgrade_insecure_default() -> bool {
+    true
+}
+
+fn is_true(b: &bool) -> bool {
+    *b
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/taxy/src/proxy/mod.rs
+++ b/taxy/src/proxy/mod.rs
@@ -64,10 +64,15 @@ impl PortContext {
         &mut self.kind
     }
 
-    pub async fn setup(&mut self, certs: &CertList, proxies: Vec<ProxyEntry>) -> Result<(), Error> {
+    pub async fn setup(
+        &mut self,
+        ports: &[PortEntry],
+        certs: &CertList,
+        proxies: Vec<ProxyEntry>,
+    ) -> Result<(), Error> {
         match &mut self.kind {
             PortContextKind::Tcp(ctx) => ctx.setup(certs, proxies).await,
-            PortContextKind::Http(ctx) => ctx.setup(certs, proxies).await,
+            PortContextKind::Http(ctx) => ctx.setup(ports, certs, proxies).await,
             PortContextKind::Udp(ctx) => ctx.setup(proxies).await,
             PortContextKind::Reserved => Ok(()),
         }

--- a/taxy/src/server/state.rs
+++ b/taxy/src/server/state.rs
@@ -280,6 +280,7 @@ impl ServerState {
     }
 
     pub async fn reload_proxies(&mut self) {
+        let ports = self.ports.entries().cloned().collect::<Vec<_>>();
         for ctx in self.ports.as_mut_slice() {
             let proxies = self
                 .proxies
@@ -291,7 +292,7 @@ impl ServerState {
                 .collect();
             let span = span!(Level::INFO, "port", resource_id = ctx.entry.id.to_string());
             if let Err(err) = ctx
-                .setup(&self.certs, proxies)
+                .setup(&ports, &self.certs, proxies)
                 .instrument(span.clone())
                 .await
             {

--- a/taxy/tests/https_test.rs
+++ b/taxy/tests/https_test.rs
@@ -54,6 +54,7 @@ async fn https_proxy() -> anyhow::Result<()> {
                             url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
+                    upgrade_insecure: false,
                 }),
                 ..Default::default()
             },
@@ -150,6 +151,7 @@ async fn https_proxy_invalid_cert() -> anyhow::Result<()> {
                             url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
+                    upgrade_insecure: false,
                 }),
                 ..Default::default()
             },
@@ -227,6 +229,7 @@ async fn https_proxy_automatic_upgrade() -> anyhow::Result<()> {
                             url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
+                    upgrade_insecure: false,
                 }),
                 ..Default::default()
             },
@@ -319,6 +322,7 @@ async fn https_proxy_domain_fronting() -> anyhow::Result<()> {
                             url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
+                    upgrade_insecure: false,
                 }),
                 ..Default::default()
             },

--- a/taxy/tests/ws_test.rs
+++ b/taxy/tests/ws_test.rs
@@ -53,6 +53,7 @@ async fn ws_proxy() -> anyhow::Result<()> {
                             url: listen_port.http_url("/").try_into().unwrap(),
                         }],
                     }],
+                    upgrade_insecure: false,
                 }),
                 ..Default::default()
             },

--- a/taxy/tests/wss_test.rs
+++ b/taxy/tests/wss_test.rs
@@ -68,6 +68,7 @@ async fn wss_proxy() -> anyhow::Result<()> {
                             url: listen_port.https_url("/").try_into().unwrap(),
                         }],
                     }],
+                    upgrade_insecure: false,
                 }),
                 ..Default::default()
             },


### PR DESCRIPTION
Introduce a mechanism to automatically redirect HTTP requests to HTTPS, enhancing security. Update related tests and configurations to support the new behavior.