### PR TITLE
Include target server URL path in proxied requests

### DIFF
--- a/taxy-api/src/proxy.rs
+++ b/taxy-api/src/proxy.rs
@@ -123,7 +123,7 @@ pub struct Server {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(transparent)]
 #[schema(value_type = String)]
-pub struct ServerUrl(Url);
+pub struct ServerUrl(pub Url);
 
 impl ServerUrl {
     pub fn hostname(&self) -> Option<&str> {

--- a/taxy/src/proxy/http/filter.rs
+++ b/taxy/src/proxy/http/filter.rs
@@ -1,5 +1,4 @@
-use hyper::{Request, Uri};
-use std::str::FromStr;
+use hyper::Request;
 use taxy_api::proxy::Route;
 use taxy_api::vhost::VirtualHost;
 
@@ -37,8 +36,9 @@ impl RequestFilter {
             .take_while(|(a, b)| a == b)
             .count();
         if count == self.path.len() {
-            let new_path = "/".to_string() + &path.skip(count).collect::<Vec<_>>().join("/");
-            FilterResult::new(&new_path).ok()
+            Some(FilterResult {
+                path_segments: path.skip(count).map(|s| s.to_string()).collect(),
+            })
         } else {
             None
         }
@@ -47,12 +47,5 @@ impl RequestFilter {
 
 #[derive(Debug)]
 pub struct FilterResult {
-    pub uri: Uri,
-}
-
-impl FilterResult {
-    pub fn new(new_path: &str) -> anyhow::Result<Self> {
-        let uri = Uri::from_str(new_path)?;
-        Ok(Self { uri })
-    }
+    pub path_segments: Vec<String>,
 }

--- a/taxy/tests/http_test.rs
+++ b/taxy/tests/http_test.rs
@@ -36,12 +36,12 @@ async fn http_proxy() -> anyhow::Result<()> {
         .await;
 
     let mock_get_with_path = server
-        .mock("GET", "/Hello?world=1")
+        .mock("GET", "/bye/Hello?world=1")
         .match_header("via", "taxy")
         .match_header("x-real-ip", mockito::Matcher::Missing)
         .match_header("x-forwarded-proto", "http")
         .match_header("accept-encoding", "gzip, br")
-        .with_body("Hello")
+        .with_body("Bye")
         .create_async()
         .await;
 
@@ -103,7 +103,7 @@ async fn http_proxy() -> anyhow::Result<()> {
                         Route {
                             path: "/was/ist/passiert".into(),
                             servers: vec![taxy_api::proxy::Server {
-                                url: server.url().parse().unwrap(),
+                                url: format!("{}/bye", server.url()).parse().unwrap(),
                             }],
                         },
                         Route {
@@ -140,7 +140,7 @@ async fn http_proxy() -> anyhow::Result<()> {
             .await?
             .text()
             .await?;
-        assert_eq!(resp, "Hello");
+        assert_eq!(resp, "Bye");
 
         let resp = client
             .get(proxy_port.http_url("/hello/?world=1"))


### PR DESCRIPTION
Enhance the proxy functionality by incorporating the target server URL path into requests. This change improves the handling of request paths and ensures that the correct segments are appended to the proxied requests.