### PR TITLE
Rewrite Alt-Svc response header according to port configuration

### DIFF
--- a/taxy/src/proxy/http/pool.rs
+++ b/taxy/src/proxy/http/pool.rs
@@ -1,4 +1,3 @@
-use super::error::map_response;
 use crate::proxy::http::{hyper_tls::client::HttpsConnector, HTTP2_MAX_FRAME_SIZE};
 use bytes::Bytes;
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
@@ -10,6 +9,8 @@ use hyper_util::{
 use std::sync::Arc;
 use tokio_rustls::rustls::ClientConfig;
 use tracing::error;
+
+use super::rewriter::ResponseRewriter;
 
 pub struct ConnectionPool {
     client: Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, anyhow::Error>>,
@@ -76,7 +77,7 @@ impl ConnectionPool {
             error!(%err);
         }
 
-        map_response(result)
+        ResponseRewriter::default().map_response(result)
     }
 }
 

--- a/taxy/src/proxy/http/route.rs
+++ b/taxy/src/proxy/http/route.rs
@@ -28,7 +28,8 @@ impl Router {
                     route: ParsedRoute {
                         servers: route.servers,
                     },
-                    https_port: https_port.filter(|_| http.upgrade_insecure),
+                    https_port,
+                    upgrade_insecure: http.upgrade_insecure,
                 });
             }
         }
@@ -55,6 +56,7 @@ pub struct FilteredRoute {
     pub filter: RequestFilter,
     pub route: ParsedRoute,
     pub https_port: Option<u16>,
+    pub upgrade_insecure: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Adjust the handling of the Alt-Svc response header to reflect the correct port configuration and include necessary updates to the routing and response mapping logic. This change enhances the proxy's ability to manage secure connections effectively.