### PR TITLE
Fix missing /ports/interfaces endpoint

### DIFF
--- a/taxy/src/admin/mod.rs
+++ b/taxy/src/admin/mod.rs
@@ -142,7 +142,8 @@ pub async fn start_admin(
         .route("/{id}/status", get(ports::status))
         .route("/{id}", put(ports::put))
         .route("/{id}", delete(ports::delete))
-        .route("/{id}/reset", get(ports::reset));
+        .route("/{id}/reset", get(ports::reset))
+        .route("/interfaces", get(ports::interfaces));
 
     let proxies_routes = Router::new()
         .route("/", get(proxies::list))

--- a/taxy/src/admin/ports.rs
+++ b/taxy/src/admin/ports.rs
@@ -1,6 +1,7 @@
 use super::{AppError, AppState};
 use crate::server::rpc::ports::{
-    AddPort, DeletePort, GetPort, GetPortList, GetPortStatus, ResetPort, UpdatePort,
+    AddPort, DeletePort, GetNetworkInterfaceList, GetPort, GetPortList, GetPortStatus, ResetPort,
+    UpdatePort,
 };
 use axum::{
     extract::{Path, State},
@@ -8,7 +9,7 @@ use axum::{
 };
 use taxy_api::{
     id::ShortId,
-    port::{Port, PortEntry, PortStatus},
+    port::{NetworkInterface, Port, PortEntry, PortStatus},
 };
 
 pub async fn list(State(state): State<AppState>) -> Result<Json<Box<Vec<PortEntry>>>, AppError> {
@@ -57,4 +58,10 @@ pub async fn reset(
     Path(id): Path<ShortId>,
 ) -> Result<Json<Box<()>>, AppError> {
     Ok(Json(state.call(ResetPort { id }).await?))
+}
+
+pub async fn interfaces(
+    State(state): State<AppState>,
+) -> Result<Json<Box<Vec<NetworkInterface>>>, AppError> {
+    Ok(Json(state.call(GetNetworkInterfaceList).await?))
 }


### PR DESCRIPTION
Add the /ports/interfaces endpoint to retrieve a list of network interfaces. 

related to #114