### PR TITLE
Use IPV6_V6ONLY flag to avoid dualstack binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,9 +3629,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3998,6 +3998,7 @@ dependencies = [
  "serde_qs",
  "sha2",
  "shellexpand",
+ "socket2",
  "sqlx",
  "tar",
  "taxy-api",

--- a/taxy/Cargo.toml
+++ b/taxy/Cargo.toml
@@ -81,6 +81,7 @@ serde_json = "1.0.102"
 serde_qs = "0.14.0"
 sha2 = "0.10.7"
 shellexpand = "3.1.0"
+socket2 = "0.5.9"
 sqlx = { version = "0.8.2", features = [
     "runtime-tokio-rustls",
     "sqlite",

--- a/taxy/src/admin/mod.rs
+++ b/taxy/src/admin/mod.rs
@@ -142,7 +142,8 @@ pub async fn start_admin(
         .route("/{id}/status", get(ports::status))
         .route("/{id}", put(ports::put))
         .route("/{id}", delete(ports::delete))
-        .route("/{id}/reset", get(ports::reset));
+        .route("/{id}/reset", get(ports::reset))
+        .route("/interfaces", get(ports::interfaces));
 
     let proxies_routes = Router::new()
         .route("/", get(proxies::list))

--- a/taxy/src/admin/ports.rs
+++ b/taxy/src/admin/ports.rs
@@ -1,6 +1,7 @@
 use super::{AppError, AppState};
 use crate::server::rpc::ports::{
-    AddPort, DeletePort, GetPort, GetPortList, GetPortStatus, ResetPort, UpdatePort,
+    AddPort, DeletePort, GetNetworkInterfaceList, GetPort, GetPortList, GetPortStatus, ResetPort,
+    UpdatePort,
 };
 use axum::{
     extract::{Path, State},
@@ -8,7 +9,7 @@ use axum::{
 };
 use taxy_api::{
     id::ShortId,
-    port::{Port, PortEntry, PortStatus},
+    port::{NetworkInterface, Port, PortEntry, PortStatus},
 };
 
 pub async fn list(State(state): State<AppState>) -> Result<Json<Box<Vec<PortEntry>>>, AppError> {
@@ -57,4 +58,10 @@ pub async fn reset(
     Path(id): Path<ShortId>,
 ) -> Result<Json<Box<()>>, AppError> {
     Ok(Json(state.call(ResetPort { id }).await?))
+}
+
+pub async fn interfaces(
+    State(state): State<AppState>,
+) -> Result<Json<Box<Vec<NetworkInterface>>>, AppError> {
+    Ok(Json(state.call(GetNetworkInterfaceList).await?))
 }


### PR DESCRIPTION
Implement the `IPV6_V6ONLY` flag to ensure that TCP and UDP sockets bind exclusively to IPv6 addresses, preventing dual-stack binding. 