### PR TITLE
Ensure Host Header is forwarded

### DIFF
--- a/taxy/src/proxy/http/rewriter.rs
+++ b/taxy/src/proxy/http/rewriter.rs
@@ -125,7 +125,8 @@ impl RequestRewriter {
 
         if let Some(host) = &header_host {
             if let Ok(host) = HeaderValue::from_str(host) {
-                headers.insert("x-forwarded-host", host);
+                headers.insert("x-forwarded-host", host.clone());
+                headers.insert("host", host);
             }
         }
     }
@@ -332,10 +333,12 @@ mod test {
     #[test]
     fn test_header_rewriter_post_process() {
         let mut headers = HeaderMap::new();
+        headers.append("host", "taxy.dev".parse().unwrap());
         let rewriter = RequestRewriter::builder()
             .set_via("taxy".parse().unwrap())
             .build();
         rewriter.post_process(&mut headers);
         assert_eq!(headers.get("via").unwrap(), "taxy");
+        assert_eq!(headers.get("host").unwrap(), "taxy.dev");
     }
 }


### PR DESCRIPTION
For issue #124 

This pull request updates the HTTP header rewriting logic in `RequestRewriter` to ensure the `host` header is set correctly, and adds a corresponding test to verify this behavior.

Header rewriting improvements:

* Updated the `post_process` method in `RequestRewriter` to explicitly set the `host` header along with the `x-forwarded-host` header, ensuring both are present and consistent in outgoing requests.

Testing enhancements:

* Added a test in `test_header_rewriter_post_process` to check that the `host` header is set to `"taxy.dev"` after rewriting, improving test coverage for header handling.